### PR TITLE
Alterando alguns imports e adicionando mais comandos ao manager

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,22 +1,24 @@
 from flask import Flask
-from flask_script import Manager
-from flask_sqlalchemy import SQLAlchemy
+from flask_script import Server, Manager, prompt_bool
+#from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate, MigrateCommand
 from flask_login import LoginManager
 import os
 
-config = {
-    "development": 'config.development',
-    'production': 'config.production',
-    'default': 'config.default'
+configs = {
+    'development': '../config/development.py',
+    'production': '../config/production.py',
+    'default': '../config/default.py'
 }
 
 config_name = os.getenv('FLASK_CONFIGURATION', 'default')
 
 app = Flask(__name__)
-app.config.from_object(config[config_name])
+app.config.from_pyfile(configs[config_name])
 
-db = SQLAlchemy(app)
+from app.models.models import *
+
+#db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 
 login_manager = LoginManager()
@@ -26,3 +28,15 @@ from app.controllers import routes
 
 manager = Manager(app)
 manager.add_command('db', MigrateCommand)
+manager.add_command('runserver', Server(host='0.0.0.0', ssl_crt='ssl/server.crt', ssl_key='ssl/server.key'))
+
+@manager.command
+def create():
+    "Creates database tables from sqlalchemy models"
+    db.create_all()
+
+@manager.command
+def drop():
+    "Drops database tables"
+    if prompt_bool("Erase current database?"):
+        db.drop_all()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,5 @@
 from flask import Flask
 from flask_script import Server, Manager, prompt_bool
-#from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate, MigrateCommand
 from flask_login import LoginManager
 import os
@@ -18,7 +17,6 @@ app.config.from_pyfile(configs[config_name])
 
 from app.models.models import *
 
-#db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 
 login_manager = LoginManager()

--- a/app/controllers/routes.py
+++ b/app/controllers/routes.py
@@ -72,9 +72,11 @@ def cadastro():
 			return redirect(url_for('index_usuario'))
 	return render_template('cadastro.html', form=form)
 
-@login_manager.user_loader
+
+@app.login_manager.user_loader
 def user_loader(user_id):
 		return Usuario.query.get(user_id)
+
 
 #Página do link enviado para o usuário
 @app.route('/verificacao/<token>')
@@ -87,7 +89,7 @@ def verificacao(token):
 		user = db.session.query(Usuario).filter_by(email = email).first()
 		#Valida o email
 		user.email_verificado = True
-               db.session.add(user)
+		db.session.add(user)
 		db.session.commit()
 	#Tempo definido no max_age
 	except SignatureExpired:

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,9 +1,10 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
-from app import db
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Date
+from app import app
 
+db = SQLAlchemy(app)
 
 class Usuario(db.Model):
-    __tablename__ = 'usuario'
     id = Column(Integer, primary_key=True)
     participantes_associados = db.relationship('participante', backref='usuario', lazy=True)
     email = Column(String(64), unique=True, nullable=False)
@@ -35,7 +36,6 @@ class Usuario(db.Model):
 
 
 class Participante(db.Model):
-    __tablename__ = 'participante'
     id = Column(Integer, db.ForeignKey('usuario.id'), primary_key=True)
     edicao = Column(Integer, nullable=False)
     pacote = Column(Boolean, nullable=False)
@@ -46,8 +46,7 @@ class Participante(db.Model):
 
 
 class Ministrante(db.Model):
-    __tablename__ = 'ministrante'
-    id = Column(Integer, db.ForeignKey('ministrante.id'), primary_key=True)
+    id = Column(Integer, primary_key=True)
     pagar_gastos = Column(Boolean, nullable=False)
     data_chegada_sanca = Column(Date, nullable=False)
     data_saida_sanca = Column(Date, nullable=False)
@@ -67,9 +66,13 @@ class Ministrante(db.Model):
     github = Column(String(64))
 
 
+relacao_atividade_participante = db.Table('relacao_atividade_participante',
+				Column('id_atividade', Integer, db.ForeignKey('atividade.id'), primary_key=True),
+                                Column('id_participante', Integer, db.ForeignKey('participante.id'), primary_key=True))
+
+
 class Atividade(db.Model):
-    __tablename__ = 'atividade'
-    id = Column(Integer, primary_key=True)
+    id = Column(Integer, db.ForeignKey('ministrante.id'), primary_key=True)
     vagas_totais = Column(Integer, nullable=False)
     vagas_disponiveis = Column(Integer, nullable=False)
     pre_requisitos = Column(String(512), nullable=False)
@@ -82,15 +85,7 @@ class Atividade(db.Model):
     descricao = Column(String(1024), nullable=False)
     recursos_necessarios = Column(String(512), nullable=False)
     observacoes = Column(String(512), nullable=False)
-    ministrante = db.relationship('ministrante', backref='ministrante', lazy=True)
-    inscritos = db.relationship('participante', secondary=relacao_atividade_participante, lazy=True,
-        backref=db.backref('atividade', lazy='subquery'))
-
-
-relacao_atividade_participante = db.Table('relacao_atividade_participante',
-                                       Column('id_atividade', Integer, db.ForeignKey('atividade.id'), primary_key=True),
-                                       Column('id_participante', Integer, db.ForeignKey('participante.id'), primary_key=True))
-
-#if __name__ == "__main__":
-#    db.create_all()
+    ministrante = db.relationship('Ministrante', backref='ministrante', lazy=True)
+    inscritos = db.relationship('Participante', secondary=relacao_atividade_participante, lazy=True, 
+	backref=db.backref('atividade', lazy='subquery'))
 

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python3
 from app import manager
 
 if __name__ == '__main__':
-    manager.run(host='0.0.0.0', ssl_context='adhoc')
+    manager.run()
 


### PR DESCRIPTION
## Descrição
Após a resolução de conflitos do último PR o módulo app não tinha acesso aos modelos do sqlalchemy pois o objeto db era criado em `app/__init __.py`. Agora este é criado em `app/models/models.py` e então o objeto db tem acesso às classes criadas.
O arquivo principal foi alterado de `run.py` para `manage.py` pois agora pode, além de rodar o servidor, executar comandos no terminal para manipulação do banco de dados.
Foram adicionados alguns comandos novos que podem ser executados no terminal, para ver quais são basta executar `./manage.py`.
Para executar o servidor é necessário criar um certificado SSL e chave e então executar `./manage.py runserver`.
Finalmente, foram resolvidos alguns erros na declaração de modelos de ministrantes, atividades, no método de confirmação de email e todos os dados dos modelos criados agora estão em potência de 2 para padronização.