### PR TITLE
Mudanças na home e tema bootstrap personalizado.

### DIFF
--- a/app/static/bs/css/bootstrap.css
+++ b/app/static/bs/css/bootstrap.css
@@ -4677,7 +4677,8 @@ button.bg-dark:focus {
   background-color: #1d2124 !important; }
 
 .bg-gradient-primary {
-  background: #007bff linear-gradient(180deg, #268fff, #007bff) repeat-x !important; }
+  background-image: linear-gradient(to right, #008CB5, #00CFA1);
+}
 
 .bg-gradient-secondary {
   background: #6c757d linear-gradient(180deg, #828a91, #6c757d) repeat-x !important; }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -18,9 +18,20 @@
     --color15: ;
 }
 
-header{
-	  background-image: linear-gradient(to right, #008CB5, #00CFA1);
- }
+.carousel .carousel-item {
+    height: 100vh;
+    width:  100vw;
+    object-fit: fill;
+    text-shadow: 1px 1px 5px black;
+}
+
+.dropdown:hover > .dropdown-menu {
+    display: block;
+}
+.dropdown > .dropdown-toggle:active {
+    /*Without this, clicking will make it sticky*/
+    pointer-events: none;
+}
  
 header a {
 	color: #FFFFFF;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -32,7 +32,7 @@
 {% block body %}
 {% block navbar %}
 <header>
-    <nav class="navbar navbar-expand-lg">
+    <nav class="navbar fixed-top navbar-expand-lg bg-gradient-primary">
         <div class="container-fluid">
             {# Marca d'água para a home  #}
             <a class="navbar-brand ml-auto" href="{{ url_for('index') }}"><img src="{{ url_for('static', filename='images/logoTest.png') }}" width="30" height="30" alt="Logo atual da SECOMP"/></a>
@@ -101,7 +101,7 @@
 
 {# Rascunho de rodapé #}
 {% block footer %}
-<footer class="navbar font-small pt-5 text-white">
+<footer class="navbar small pt-5 text-white">
     <div class="container">
         <div class="row">
             <div class="col-md-6 align-self-left">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,37 +1,60 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section id="carrossel" class="carousel slide" style="max-height: 400px" data-ride="carousel">
-    <ol class="carousel-indicators">
-	<li data-target="#carrossel" data-slide-to="0" class="active"></li>
-	<li data-target="#carrossel" data-slide-to="1"></li>
-	<li data-target="#carrossel" data-slide-to="2"></li>
-    </ol>
-    <div class="carousel-inner">
-	<div class="carousel-item active">
-	    <img class="w-100" style="max-height: 400px; object-fit: cover;" src="{{url_for('static', filename='images/car1.jpg')}}">
-	</div>
-	<div class="carousel-item">
-	    <img class="w-100" style="max-height: 400px; object-fit: cover;" src="{{url_for('static', filename='images/car2.jpg')}}">
-	</div>
-	<div class="carousel-item">
-	    <img class="w-100" style="max-height: 400px; object-fit: cover;" src="{{url_for('static', filename='images/car3.jpg')}}">
-	</div>
-    </div>
-    <a class="carousel-control-prev" href="#carrossel" role="button" data-slide="prev">
-	<span class="carousel-control-prev-icon" aria-hidden="true"></span>
-	<span class="sr-only">Previous</span>
-    </a>
-    <a class="carousel-control-next" href="#carrossel" role="button" data-slide="next">
-	<span class="carousel-control-next-icon" aria-hidden="true"></span>
-	<span class="sr-only">Next</span>
-    </a>
-</section> 
+<div class="container-fluid px-0">
+	<section id="carrossel" class="carousel slide" data-ride="carousel">
+		<ol class="carousel-indicators">
+			<li data-target="#carrossel" data-slide-to="0" class="active"></li>
+			<li data-target="#carrossel" data-slide-to="1"></li>
+			<li data-target="#carrossel" data-slide-to="2"></li>
+		</ol>
+		<div class="carousel-inner">
+			<div class="carousel-item active">
+				<div class="d-flex align-items-center justify-content-center min-vh-100">
+					<img class="w-100 img-fluid " src="{{url_for('static', filename='images/car1.jpg')}}">
+					<div class="carousel-caption d-none d-md-block">
+						<h1>Título 1</h1>
+						<p>Tellus tempus senectus ante nostra netus, nisl ultrices ultricies tempor gravida, malesuada natoque magnis
+							ridiculus, neque porttitor magna. Cras cum risus ut natoque ornare, magnis hymenaeos lorem conubia.</p>
+					</div>
+				</div>
+			</div>
+			<div class="carousel-item">
+				<div class="d-flex align-items-center justify-content-center min-vh-100">
+					<img class="w-100 img-fluid" src="{{url_for('static', filename='images/car2.jpg')}}">
+					<div class="carousel-caption d-none d-md-block">
+						<h1>Título 2</h1>
+						<p>Tellus tempus senectus ante nostra netus, nisl ultrices ultricies tempor gravida, malesuada natoque magnis
+							ridiculus, neque porttitor magna. Cras cum risus ut natoque ornare, magnis hymenaeos lorem conubia.</p>
+					</div>
+				</div>
+			</div>
+			<div class="carousel-item">
+				<div class="d-flex align-items-center justify-content-center min-vh-100">
+					<img class="w-100 img-fluid" src="{{url_for('static', filename='images/car3.jpg')}}">
+					<div class="carousel-caption d-none d-md-block">
+						<h1>Título 3</h1>
+						<p>Tellus tempus senectus ante nostra netus, nisl ultrices ultricies tempor gravida, malesuada natoque magnis
+							ridiculus, neque porttitor magna. Cras cum risus ut natoque ornare, magnis hymenaeos lorem conubia.</p>
+					</div>
+				</div>
+			</div>
+		</div>
+		<a class="carousel-control-prev" href="#carrossel" role="button" data-slide="prev">
+			<span class="carousel-control-prev-icon" aria-hidden="true"></span>
+			<span class="sr-only">Previous</span>
+		</a>
+		<a class="carousel-control-next" href="#carrossel" role="button" data-slide="next">
+			<span class="carousel-control-next-icon" aria-hidden="true"></span>
+			<span class="sr-only">Next</span>
+		</a>
+	</section>
+</div>
 
 <div class="container mt-4 mb-4">
-    <h1 class="display-5">SECOMP UFSCar 2019</h1>
-    {# Texto adicional para testar espaçamento #}
-    {{ lipsum() }}
+	<h1 class="display-5">SECOMP UFSCar 2019</h1>
+	{# Texto adicional para testar espaçamento #}
+	{{ lipsum() }}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
### Alterações
- Gradiente adicionado no tema do bootstrap 
- Carousel ocupa tela inteira e tem descrição 
- Dropdown é ativado no hover 
- Letras estão pequenas no footer

### Tema bootstrap
Para evitar gambiarras e facilitar o desenvolvimento, podemos alterar o tema do bootstrap em [/static/bs/css/bootstrap.css](https://github.com/secompufscar/site-secomp/blob/frontEnd/app/static/bs/css/bootstrap.css) .

Podemos colocar as cores da SECOMP, **gradientes**, e estilo de texto. Para usar, basta referenciar a classe no html, sem a necessidade de alterar o css constantemente.

### Screenshots

![image](https://user-images.githubusercontent.com/26843282/54867552-34d3b680-4d60-11e9-8034-a49c31775e13.png)
![image](https://user-images.githubusercontent.com/26843282/54867560-40bf7880-4d60-11e9-950f-2d63bb6bb209.png)
